### PR TITLE
Remove 2 minute wait

### DIFF
--- a/roles/consul/tasks/consul_bootstrap.yml
+++ b/roles/consul/tasks/consul_bootstrap.yml
@@ -1,15 +1,4 @@
 ---
-# only wait on this node
-
-# removing wait
-#- name: wait for cluster to elect leader
-#  ansible.builtin.pause:
-#    minutes: 2
-#  run_once: true
-#  delegate_to: "localhost"   
-
-# do an until
-
 - name: bootstrap consul 
   ansible.builtin.shell: consul acl bootstrap
   register: result

--- a/roles/consul/tasks/consul_bootstrap.yml
+++ b/roles/consul/tasks/consul_bootstrap.yml
@@ -1,14 +1,21 @@
 ---
 # only wait on this node
-- name: wait for cluster to elect leader
-  ansible.builtin.pause:
-    minutes: 2
-  run_once: true
-  delegate_to: "localhost"   
+
+# removing wait
+#- name: wait for cluster to elect leader
+#  ansible.builtin.pause:
+#    minutes: 2
+#  run_once: true
+#  delegate_to: "localhost"   
+
+# do an until
 
 - name: bootstrap consul 
   ansible.builtin.shell: consul acl bootstrap
-  register: result 
+  register: result
+  until: "result is not failed"
+  retries: 3
+  delay: 3
   run_once: true
   delegate_to: "{{ groups['nomad_cluster'][0] }}"
 

--- a/roles/consul/tasks/consul_run.yml
+++ b/roles/consul/tasks/consul_run.yml
@@ -8,13 +8,6 @@
   loop: "{{ groups['nomad_client'] }}"
   when: cluster_mode == 'client'
 
-
-# diee. debug
-- name: stopping further execution
-  meta: end_play
-  run_once: true
-  delegate_to: "localhost"
-
 - name: start and enable consul service
   systemd: 
     name: consul

--- a/roles/consul/tasks/consul_run.yml
+++ b/roles/consul/tasks/consul_run.yml
@@ -1,5 +1,6 @@
 ---
 # start service on cluster when cluster_mode is client
+
 - name: systemd daemon reload
   systemd: 
     daemon_reload: yes

--- a/roles/consul/tasks/consul_run.yml
+++ b/roles/consul/tasks/consul_run.yml
@@ -8,6 +8,14 @@
   loop: "{{ groups['nomad_client'] }}"
   when: cluster_mode == 'client'
 
+
+# diee. debug
+- name: stopping further execution
+  fail:
+    msg: "Stopping execution for manual testing"
+  run_once: true
+  delegate_to: "localhost"
+
 - name: start and enable consul service
   systemd: 
     name: consul

--- a/roles/consul/tasks/consul_run.yml
+++ b/roles/consul/tasks/consul_run.yml
@@ -11,8 +11,7 @@
 
 # diee. debug
 - name: stopping further execution
-  fail:
-    msg: "Stopping execution for manual testing"
+  meta: end_play
   run_once: true
   delegate_to: "localhost"
 

--- a/roles/nomad/tasks/nomad_bootstrap.yml
+++ b/roles/nomad/tasks/nomad_bootstrap.yml
@@ -1,11 +1,4 @@
 ---
-#remove 
-#- name: wait for nomad to elect leader
-#  ansible.builtin.pause: 
-#    minutes: 2
-#  run_once: true
-#  delegate_to: localhost
-
 - name: bootstrap nomad
   ansible.builtin.shell: nomad acl bootstrap
   register: result

--- a/roles/nomad/tasks/nomad_bootstrap.yml
+++ b/roles/nomad/tasks/nomad_bootstrap.yml
@@ -1,13 +1,17 @@
 ---
-- name: wait for nomad to elect leader
-  ansible.builtin.pause: 
-    minutes: 2
-  run_once: true
-  delegate_to: localhost
+#remove 
+#- name: wait for nomad to elect leader
+#  ansible.builtin.pause: 
+#    minutes: 2
+#  run_once: true
+#  delegate_to: localhost
 
 - name: bootstrap nomad
   ansible.builtin.shell: nomad acl bootstrap
   register: result
+  until: "result is not failed"
+  retries: 3
+  delay: 3  
   run_once: true
   delegate_to: "{{ groups['nomad_cluster'][0] }}"
 


### PR DESCRIPTION
We don't need the 2 minute pause. Once the services start they will auto-discover and elect. Adding an until on the bootstrap seems more logical