### PR TITLE
Add certbot dry-run handling

### DIFF
--- a/roles/nomad/tasks/nginx.yml
+++ b/roles/nomad/tasks/nginx.yml
@@ -58,15 +58,27 @@
   run_once: true
   delegate_to: "{{ groups['nomad_cluster'][0] }}"
 
-# run dry run. If good, then proceed
-
-- name: run certbot
+# allow propagation
+- name: run certbot dry-run
   shell:
-    #cmd: "certbot -n --nginx --agree-tos --redirect -d {{ rdns }} -m {{ email_address }}"
-    cmd: certbot certonly -n --webroot --dry-run --agree-tos --redirect -d {{ rdns }} -m {{ email_address }} -w /var/www/html
+    cmd: "certbot certonly -n --webroot --dry-run --agree-tos --redirect -d {{ rdns }} -m {{ email_address }} -w /var/www/html"
+  run_once: true
+  delegate_to: "{{ groups['nomad_cluster'][0] }}"
+  register: dry_run
+  until: dry_run is not failed
+  retries: 3
+  delay: 3
+  ignore_errors: true
+
+- name: validate certbot dry-run
+  assert:
+    that: dry_run is not failed
+    fail_msg: "[Error] Certbot dry-run failed. Cannot continue..Check the domain provided"
+    success_msg: "[Info] Certbot dry-run successful!"
   run_once: true
   delegate_to: "{{ groups['nomad_cluster'][0] }}"
 
+# issue cert
 - name: run certbot
   shell:
     cmd: "certbot -n --nginx --agree-tos --redirect -d {{ rdns }} -m {{ email_address }}"

--- a/roles/nomad/tasks/nginx.yml
+++ b/roles/nomad/tasks/nginx.yml
@@ -65,7 +65,7 @@
     #cmd: "certbot -n --nginx --agree-tos --redirect -d {{ rdns }} -m {{ email_address }}"
     cmd: certbot certonly -n --webroot --dry-run --agree-tos --redirect -d {{ rdns }} -m {{ email_address }} -w /var/www/html
   run_once: true
-  delegate_to: "{{ groups['nomad_cluster'][0] }}
+  delegate_to: "{{ groups['nomad_cluster'][0] }}"
 
 - name: run certbot
   shell:

--- a/roles/nomad/tasks/nginx.yml
+++ b/roles/nomad/tasks/nginx.yml
@@ -50,6 +50,23 @@
   run_once: true
   delegate_to: "{{ groups['nomad_cluster'][0] }}"
 
+# fail to work from here
+
+- name: failing to work from here
+  fail:
+    msg: "[-] setting breakpoint..."
+  run_once: true
+  delegate_to: "{{ groups['nomad_cluster'][0] }}"
+
+# run dry run. If good, then proceed
+
+- name: run certbot
+  shell:
+    #cmd: "certbot -n --nginx --agree-tos --redirect -d {{ rdns }} -m {{ email_address }}"
+    cmd: certbot certonly -n --webroot --dry-run --agree-tos --redirect -d {{ rdns }} -m {{ email_address }} -w /var/www/html
+  run_once: true
+  delegate_to: "{{ groups['nomad_cluster'][0] }}
+
 - name: run certbot
   shell:
     cmd: "certbot -n --nginx --agree-tos --redirect -d {{ rdns }} -m {{ email_address }}"

--- a/roles/nomad/tasks/nginx.yml
+++ b/roles/nomad/tasks/nginx.yml
@@ -50,14 +50,6 @@
   run_once: true
   delegate_to: "{{ groups['nomad_cluster'][0] }}"
 
-# fail to work from here
-
-- name: failing to work from here
-  fail:
-    msg: "[-] setting breakpoint..."
-  run_once: true
-  delegate_to: "{{ groups['nomad_cluster'][0] }}"
-
 # allow propagation
 - name: run certbot dry-run
   shell:


### PR DESCRIPTION
allows for DNS propagation before getting the cert. We can skip any failed propagation errors and then use assert to perform better error handling.